### PR TITLE
Adjusted for 5.0.1-patch2 of plugin-helpers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,6 @@ rm -rf build/*
 npm run build
 cd build
 zip_name=`ls *.zip`
-mkdir kibana
-unzip logtrail*.zip -d kibana
+unzip logtrail*.zip
 cp ../logtrail.json kibana/logtrail-*/
 zip -r $zip_name kibana/


### PR DESCRIPTION
I removed the creation of the `/kibana` folder manually since the latest plugin-helpers will create that folder for you when building.