### PR TITLE
Use ISO 8601 string for range timestamp

### DIFF
--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -95,9 +95,11 @@ module.exports = function (server) {
         if (selected_config.default_time_range_in_days !== 0) {
           var moment = require('moment');
           timestamp = moment().subtract(
-            selected_config.default_time_range_in_days,'days').startOf('day').valueOf();
+            selected_config.default_time_range_in_days,'days').startOf('day').toISOString();
           rangeType = 'gte';
         }
+      } else {
+        timestamp = moment(timestamp).toISOString();
       }
       //If timestamps are present set ranges
       if (timestamp != null) {
@@ -110,7 +112,7 @@ module.exports = function (server) {
         range[selected_config.fields.mapping.timestamp] = {};
         range[selected_config.fields.mapping.timestamp][rangeType] = timestamp;
         range[selected_config.fields.mapping.timestamp].time_zone = selected_config.es.timezone;
-        range[selected_config.fields.mapping.timestamp].format = 'epoch_millis';
+        range[selected_config.fields.mapping.timestamp].format = 'strict_date_optional_time';
         searchRequest.body.query.filtered.filter.bool.must.push(rangeQuery);
       }
       //console.log(JSON.stringify(searchRequest));


### PR DESCRIPTION
Works around issue with ES not supporting time_zone parameter on epoch timestamp formats:
https://github.com/elastic/elasticsearch/issues/22621

Fixes: https://github.com/sivasamyk/logtrail/issues/24