### PR TITLE
moment-timezone is a replacement for moment, not an add-on.

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3,8 +3,7 @@ var routes = require('ui/routes');
 var modules = require('ui/modules');
 var angular = require('angular');
 var sugarDate = require('sugar-date');
-var moment = require('moment');
-var momentTimezone = require('moment-timezone');
+var moment = require('moment-timezone');
 
 require('plugins/logtrail/css/main.css');
 


### PR DESCRIPTION
Don't require both. Doing it this way does not make any of the TZ functionality available to moment.

Fixes:
```
TypeError: display_timestamp.tz is not a function
    at addParsedTimestamp (logtrail.bundle.js?v=14588:1)
    at updateEventView (logtrail.bundle.js?v=14588:1)
    at logtrail.bundle.js?v=14588:1
    at processQueue (commons.bundle.js?v=14588:38)
    at commons.bundle.js?v=14588:38
    at Scope.$eval (commons.bundle.js?v=14588:39)
    at Scope.$digest (commons.bundle.js?v=14588:39)
    at Scope.$apply (commons.bundle.js?v=14588:39)
    at done (commons.bundle.js?v=14588:37)
    at completeRequest (commons.bundle.js?v=14588:37)
```