### PR TITLE
Changes to add severity field and colloring

### DIFF
--- a/logtrail.json
+++ b/logtrail.json
@@ -8,10 +8,10 @@
       "tail_interval_in_seconds": 10,
       "es_index_time_offset_in_seconds": 0,
       "display_timezone": "local",
-      "display_timestamp_format": "MMM DD HH:mm:ss",
+      "display_timestamp_format": "YYYY-MM-DD HH:mm:ss.SSS",
       "max_buckets": 500,
       "nested_objects" : false,
-      "default_time_range_in_days" : 0,
+      "default_time_range_in_days" : 1,
       "max_hosts": 100,
       "max_events_to_keep_in_viewer": 5000,
       "fields" : {
@@ -20,10 +20,11 @@
             "display_timestamp" : "@timestamp",
             "hostname" : "hostname",
             "program": "program",
-            "message": "syslog_message"
+            "message": "syslog_message",
+            "severity": "severity"
         },
         "message_format": "{{syslog_message}}"
       }
-    }  
+    }
   ]
 }

--- a/public/app.js
+++ b/public/app.js
@@ -448,6 +448,11 @@ app.controller('logtrail', function ($scope, kbnUrl, $route, $routeParams,
     $scope.onSearchClick();
   };
 
+  $scope.onSeverityClick = function (severity) {
+    $scope.userSearchText = selected_index_config.fields.mapping['severity'] + ': "' + severity + '"';
+    $scope.onSearchClick();
+  };
+
   $scope.onClick = function (name,value) {
     $scope.userSearchText = name + ': "' + value + '"';
     $scope.onSearchClick();

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -101,15 +101,58 @@ html,body {
 	color: #258CCD;
 }
 
+.program.Error a {
+	color: #ff3333;
+}
+
 .program a:hover {
 	text-decoration: none;
 }
 
 .message {
-	color: #B0B0B0;	
+	color: #258CCD;	
 	word-break: break-all;
     word-wrap: break-word;
     white-space: pre-wrap;
+}
+
+.message-error a {
+	color: #ff3333;	
+}
+
+.message-warning a {
+	color: #ffff33;	
+}
+
+.message-info a {
+	color: #33cc33;	
+}
+
+.message-debug a {
+	color: #B0B0B0;	
+}
+
+.severity {
+	color: #258CCD;	
+	word-break: break-all;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+}
+
+.severity-error a{
+	color: #ff3333;	
+}
+
+.severity-warning a {
+	color: #ffff33;	
+}
+
+.severity-info a {
+	color: #33cc33;	
+}
+
+.severity-debug a {
+	color: #B0B0B0;	
 }
 
 .flex-container-search {

--- a/public/templates/index.html
+++ b/public/templates/index.html
@@ -9,10 +9,11 @@
   </div>
   <ul class="events">
     <li id="{{ event.id }}" ng-repeat="event in events" on-last-repeat infinite-scroll>
-      <time>{{ event.display_timestamp }}</time>
+      <time style="color: #258CCD">{{ event.display_timestamp }}</time>
       <span class='host'><a href ng-click="onHostSelected(event.hostname)">{{ event.hostname }}</a></span>
-      <span class='program'><a ng-click="onProgramClick(event.program)">{{ event.program }}:</a></span>
-      <span class="message" ng-bind-html="event.message" compile-template/>
+      <span class='program'><a ng-click="onProgramClick(event.program)">{{ event.program }}</a></span>
+      <span class='severity-{{ event.severity }}'><a ng-click="onSeverityClick(event.severity)">[{{ event.severity }}]:</a></span>
+      <span class="message-{{ event.severity }}" ng-bind-html="event.message" compile-template/>
     </li>
   </ul>
 

--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -1,7 +1,7 @@
 function getMessageTemplate(handlebar, selected_config) {
   var message_format = selected_config.fields.message_format;
   //Append <a> tags for click to message format except for message field    
-    var message_format_regex = /({{(\S+)}})/g; // e.g. {{pid}} : {{syslog_message}}    
+    var message_format_regex = /({{(\S+)}})/g; // e.g. {{pid}} : {{syslog_message}}   
     var ng_click_template = handlebar.compile("<a class=\"ng-binding\" ng-click=\"onClick('{{name_no_braces}}','{{name}}')\">{{name}}</a>");
     var messageField = "{{" + selected_config.fields.mapping.message + "}}";
     var message_template = message_format;
@@ -45,6 +45,10 @@ function convertToClientFormat(selected_config, esResponse) {
     event['display_timestamp'] = source[selected_config.fields.mapping['display_timestamp']];
     event['hostname'] = source[selected_config.fields.mapping['hostname']];
     event['program'] = source[selected_config.fields.mapping['program']];
+    if ( source[selected_config.fields.mapping['severity']] )
+    	event['severity'] = source[selected_config.fields.mapping['severity']].toLowerCase();
+    else
+    	event['severity'] = source[selected_config.fields.mapping['severity']];
     var message = source[selected_config.fields.mapping['message']];
     //If the user has specified a custom format for message field
     if (message_format) {


### PR DESCRIPTION
Hi,

https://github.com/sivasamyk/logtrail/issues/12

I've working on a customization to allow coloring messages based on new field called severity.

Right now it was made to attend our business needs, and need some work to make it more dynamic.

Bellow was what I've done.

New field called severity, that can be used on field mapping, like bellow:

> "fields" : {
> "mapping" : {
> "timestamp" : "@timestamp",
> "display_timestamp" : "@timestamp",
> "hostname" : "beat.hostname",
> "program": "fields.node",
> "message": "message",
> "severity": "severity"
> },

Changed the css class and added four different classes for message and severity like bellow.

> .message {
> color: #258CCD;
> word-break: break-all;
> word-wrap: break-word;
> white-space: pre-wrap;
> }
> 
> .message-error a {
> color: #ff3333;
> }
> 
> .message-warning a {
> color: #ffff33;
> }
> 
> .message-info a {
> color: #33cc33;
> }
> 
> .message-debug a {
> color: #B0B0B0;
> }
> 
> .severity {
> color: #258CCD;
> word-break: break-all;
> word-wrap: break-word;
> white-space: pre-wrap;
> }
> 
> .severity-error a{
> color: #ff3333;
> }
> 
> .severity-warning a {
> color: #ffff33;
> }
> 
> .severity-info a {
> color: #33cc33;
> }
> 
> .severity-debug a {
> color: #B0B0B0;
> }

A small change on server.js to support the new field.
Now, my questions are, if that's interesting for community, how to share it and what is the way to add this to the project.

Best Regards,
Reiner