### PR TITLE
Use kibana.version correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "logtrail",
   "version": "0.1.17",
-  "kibana.version": "5.5.0",
   "description": "Plugin to view, search & tail logs in Kibana",
   "main": "index.js",
+  "kibana": {
+    "version": "5.5.0"
+  },
   "scripts": {
     "lint": "eslint",
     "start": "plugin-helpers start",


### PR DESCRIPTION
For the `kibana.version` setting to work correctly, it needs to be a `version` property in the `kibana` object.

Updated the package.json file here to work correctly. Probably a good idea to backport this to any other branched you're continuing to support. Cheers!