### PR TITLE
Issue 163

### DIFF
--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -125,6 +125,7 @@ module.exports = function (server) {
       };
       //Enable highlightng on message field
       searchRequest.body.highlight.fields[selected_config.fields.mapping['message']] = {
+        number_of_fragments: 0
       };
 
       //By default Set sorting column to timestamp


### PR DESCRIPTION
Fixed issue #163. By default ES fragment size will be 100. Setting number_of_fragments to 0 will return whole content. Refer https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html#_highlighted_fragments