### PR TITLE
Stringify objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logtrail",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Plugin to view, search & tail logs in Kibana",
   "main": "index.js",
   "kibana": {

--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -7,8 +7,8 @@ function getMessageTemplate(handlebar, selectedConfig) {
       knownHelpers: {
         log: false,
         lookup: false
-      },
-      knownHelpersOnly: true
+      }
+      //, knownHelpersOnly: true
     });
   var messageField = '{{{' + selectedConfig.fields.mapping.message + '}}}';
   var messageTemplate = messageFormat;
@@ -28,20 +28,28 @@ function getMessageTemplate(handlebar, selectedConfig) {
   return messageTemplate; //<a class="ng-binding" ng-click="onClick('pid','{{pid}}')">{{pid}}</a> : {{syslog_message}}
 }
 
+function handlebars() {
+  var handlebar = require('handlebars');
+  handlebar.registerHelper('json', function(context) {
+    return JSON.stringify(context);
+  });
+  return handlebar
+}
+
 function convertToClientFormat(selectedConfig, esResponse) {
   var clientResponse = [];
   var hits = esResponse.hits.hits;
   var template = null;
   var messageFormat = selectedConfig.fields.message_format;
   if (messageFormat) {
-    var handlebar = require('handlebars');
+    handlebar = handlebars()
     var messageTemplate = getMessageTemplate(handlebar, selectedConfig);
     template = handlebar.compile(messageTemplate, {
       knownHelpers: {
         log: false,
         lookup: false
-      },
-      knownHelpersOnly: true
+      }
+      //, knownHelpersOnly: true
     });
   }
   for (let i = 0; i < hits.length; i++) {
@@ -218,7 +226,7 @@ module.exports = function (server) {
       const { callWithRequest } = server.plugins.elasticsearch.getCluster('data');
       var selectedConfig = request.payload.config;
       var index = request.payload.index;
-      
+
       var hostnameField = selectedConfig.fields.mapping.hostname;
       let keywordSuffix = selectedConfig.fields.keyword_suffix;
       if (keywordSuffix == undefined) {

--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -47,8 +47,7 @@ function convertToClientFormat(selectedConfig, esResponse) {
       knownHelpers: {
         log: false,
         lookup: false
-      },
-      knownHelpersOnly: true
+      }
     });
   }
   for (let i = 0; i < hits.length; i++) {

--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -42,7 +42,7 @@ function convertToClientFormat(selectedConfig, esResponse) {
   var template = null;
   var messageFormat = selectedConfig.fields.message_format;
   if (messageFormat) {
-    handlebar = handlebars()
+    var handlebar = handlebars()
     var messageTemplate = getMessageTemplate(handlebar, selectedConfig);
     template = handlebar.compile(messageTemplate, {
       knownHelpers: {

--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -8,7 +8,6 @@ function getMessageTemplate(handlebar, selectedConfig) {
         log: false,
         lookup: false
       }
-      //, knownHelpersOnly: true
     });
   var messageField = '{{{' + selectedConfig.fields.mapping.message + '}}}';
   var messageTemplate = messageFormat;
@@ -48,8 +47,8 @@ function convertToClientFormat(selectedConfig, esResponse) {
       knownHelpers: {
         log: false,
         lookup: false
-      }
-      //, knownHelpersOnly: true
+      },
+      knownHelpersOnly: true
     });
   }
   for (let i = 0; i < hits.length; i++) {


### PR DESCRIPTION
Currently objects displayed as `[object Object]`

for example, for event `{message: "blabla", meta: {ip: "1.2.3.4", user_id: 123}}` and format `"{{message}} {{meta}}"` 
Result will be `"blabla [object Object]"`

This PR adds helper to display objects as JSON:
`"{{message}} {{json meta}}"` 
Result will be `"blabla {ip: "1.2.3.4", user_id: 123}"`