### PR TITLE
Secondary sort on "offset" column for log entries submitted within the same timestamp.

### DIFF
--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -160,6 +160,9 @@ module.exports = function (server) {
       //By default Set sorting column to timestamp
       searchRequest.body.sort[0][selectedConfig.fields.mapping.timestamp] = {'order':request.payload.order ,'unmapped_type': 'boolean'};
 
+      //apoland - secondary sort on "offset" column for log entries submitted within the same timestamp
+      searchRequest.body.sort[0].push("offset")
+	    
       //If hostname is present then term query.
       if (request.payload.hostname != null) {
         var termQuery = {

--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -161,7 +161,7 @@ module.exports = function (server) {
       searchRequest.body.sort[0][selectedConfig.fields.mapping.timestamp] = {'order':request.payload.order ,'unmapped_type': 'boolean'};
 
       //apoland - secondary sort on "offset" column for log entries submitted within the same timestamp
-      searchRequest.body.sort[0].push("offset")
+      searchRequest.body.sort.push("offset")
 	    
       //If hostname is present then term query.
       if (request.payload.hostname != null) {


### PR DESCRIPTION
Applications that generated multiple log messages show up in Filebeat using the same timestamp. Using "offset" as a secondary sort helps solve this problem.