### PR TITLE
Changes to support secondary sort field.

### DIFF
--- a/logtrail.json
+++ b/logtrail.json
@@ -22,7 +22,8 @@
             "message": "message"
         },
         "message_format": "{{{message}}}",
-        "keyword_suffix" : "keyword"
+        "keyword_suffix" : "keyword",
+        "secondary_sort_field": "offset"
       },
       "color_mapping" : {
       }

--- a/server/routes/server.js
+++ b/server/routes/server.js
@@ -160,6 +160,14 @@ module.exports = function (server) {
       //By default Set sorting column to timestamp
       searchRequest.body.sort[0][selectedConfig.fields.mapping.timestamp] = {'order':request.payload.order ,'unmapped_type': 'boolean'};
 
+      // If secondary sorting field is present then set secondary sort.
+      let secondarySortField = selectedConfig.fields.secondary_sort_field;
+      if (secondarySortField != undefined) {
+        if (secondarySortField.length > 0) {
+          searchRequest.body.sort.push(secondarySortField)
+        }
+      }
+
       //If hostname is present then term query.
       if (request.payload.hostname != null) {
         var termQuery = {


### PR DESCRIPTION
* Changes to support secondary sort field if defined. 

* Added default secondary sort field used by Filebeat.
* Secondary sort field only gets set during search if defined and has a value. if not defined then use regular behavior (sort by timestamp).